### PR TITLE
Add Battle for Wesnoth support

### DIFF
--- a/examples/incomplete/wesnoth64.conf
+++ b/examples/incomplete/wesnoth64.conf
@@ -11,7 +11,6 @@ wesnoth
 #       advancing multiple levels at once.
 # TODO: Experience: Need toggling between watching and active.
 # TODO: Need direct C string support to read the name of the unit.
-# TODO: Gold modification in development
 
 
 # Team check. Player controls team 1. Others at 2, 3, 4, etc.
@@ -82,10 +81,13 @@ check this u8 l 2
 dynmemend
 
 
-# Still unreliable. Works for some missions.
-# Likely more constructors and a check are required.
+# Use dynmem growing by multiplication (1..5 * 976):
 
-dynmemstart PlayerData 2928 0x75f79d 0x8
+#  75f791:       49 69 ff d0 03 00 00    imul   $0x3d0,%r15,%rdi
+#  75f798:       e8 f3 78 ba ff          callq  307090 <_Znwm@plt>
+#  75f79d:       49 89 c7                mov    %rax,%r15
+
+dynmemgrow PlayerData 1 5 *976 0x75f79d 0x8
 
 Gold 0x8 i32 l 800 5,0 a
 

--- a/examples/incomplete/wesnoth64.conf
+++ b/examples/incomplete/wesnoth64.conf
@@ -6,10 +6,7 @@ wesnoth
 # Health: Frozen to at least 200
 # Moves:  Frozen to at least 20
 # Attack: Can always attack.
-# Watching experience (current, max) and unit level
-# TODO: Need experience = (experience_max - 1) handling to avoid
-#       advancing multiple levels at once.
-# TODO: Experience: Need toggling between watching and active.
+# Experience: Watching max and unit level, setting current to max - 1
 
 # Find constructors:
 # objdump -D `which wesnoth` 2>&1 | grep -A20 "\$0x750,%edi" | grep -A1 _Znwm | grep -v _Znwm | cut -d ':' -f1 > addrs.txt
@@ -47,7 +44,7 @@ Health prev-4 i32 HealthMax 1,0 a
 
 ExpMax prev+12 i32 l 200 2,0 w
 TEAM_CHECK
-Exp prev-4 i32 ExpMax 2,0 w
+Exp prev-4 i32 l ExpMax-1 2,0 a
 Level prev+8 i32 watch
 
 MovesMax 0x17c i32 l 20 3,0 a
@@ -57,6 +54,78 @@ Moves prev-4 i32 MovesMax 3,0 a
 # Often set/unset together with a bool at 0x2ba
 CanAttack 0x2d4 u8 max 4,0 a
 TEAM_CHECK
+check this u8 l 2
+
+dynmemend
+
+
+# Units after level up, smaller size, lower offsets
+#
+# Find constructors:
+# objdump -D `which wesnoth` 2>&1 | grep -A20 "\$0x740,%edi" | grep -A1 _Znwm | grep -v _Znwm | cut -d ':' -f1 > addrs.txt
+# IFS=$'\n'; for i in `sed /--/d addrs.txt | tr -d [:blank:]`; do echo "dynmemconst 1856 0x$i 0x8"; done
+
+# Team check. Player controls team 1. Others at 2, 3, 4, etc.
+define TEAM_CHECK2 checko 0x154 i32 e 1
+
+
+dynmemstart Unit2 1856 0x482e86 0x8
+dynmemconst 1856 0x482e9e 0x8
+dynmemconst 1856 0x48312a 0x8
+dynmemconst 1856 0x483142 0x8
+dynmemconst 1856 0x572f34 0x8
+dynmemconst 1856 0x572f4c 0x8
+dynmemconst 1856 0x58c08b 0x8
+dynmemconst 1856 0x58c0b1 0x8
+dynmemconst 1856 0x5be982 0x8
+dynmemconst 1856 0x5be9a8 0x8
+dynmemconst 1856 0x5ca726 0x8
+dynmemconst 1856 0x5ca74c 0x8
+dynmemconst 1856 0x5ccfc1 0x8
+dynmemconst 1856 0x5ccfe5 0x8
+dynmemconst 1856 0x5cd087 0x8
+dynmemconst 1856 0x5cd0ad 0x8
+dynmemconst 1856 0x5cd4c3 0x8
+dynmemconst 1856 0x5cd4e9 0x8
+dynmemconst 1856 0x5cfcf9 0x8
+dynmemconst 1856 0x5cfd1f 0x8
+dynmemconst 1856 0x5d00f4 0x8
+dynmemconst 1856 0x5d011a 0x8
+dynmemconst 1856 0x5e74dd 0x8
+dynmemconst 1856 0x5e7500 0x8
+dynmemconst 1856 0x5e77ed 0x8
+dynmemconst 1856 0x5e7812 0x8
+dynmemconst 1856 0x65083a 0x8
+dynmemconst 1856 0x650852 0x8
+dynmemconst 1856 0x8d50a8 0x8
+dynmemconst 1856 0x8d50cc 0x8
+dynmemconst 1856 0x98b86e 0x8
+dynmemconst 1856 0x98b886 0x8
+dynmemconst 1856 0x98d86b 0x8
+dynmemconst 1856 0x98d883 0x8
+dynmemconst 1856 0x9ae6c5 0x8
+dynmemconst 1856 0x9ae6e9 0x8
+dynmemconst 1856 0xaa6df7 0x8
+dynmemconst 1856 0xaa6e1b 0x8
+
+Name2 0x68 cstr watch
+
+HealthMax2 0xd4 i32 l 200 1,0 a
+TEAM_CHECK2
+Health2 prev-4 i32 HealthMax2 1,0 a
+
+ExpMax2 prev+12 i32 l 200 2,0 w
+TEAM_CHECK2
+Exp2 prev-4 i32 l ExpMax2-1 2,0 a
+Level2 prev+8 i32 watch
+
+MovesMax2 0x16c i32 l 20 3,0 a
+TEAM_CHECK2
+Moves prev-4 i32 MovesMax2 3,0 a
+
+# Often set/unset together with a bool at 0x2ba
+CanAttack2 0x2c4 u8 max 4,0 a
+TEAM_CHECK2
 check this u8 l 2
 
 dynmemend

--- a/examples/incomplete/wesnoth64.conf
+++ b/examples/incomplete/wesnoth64.conf
@@ -1,6 +1,6 @@
 wesnoth
 
-# Battle for Wesnoth 1.15.3-lp151.38.1, openSUSE Leap 15.1, 64 bit, PIE
+# Battle for Wesnoth 1.15.5-lp151.42.2, openSUSE Leap 15.1, 64 bit, PIE
 
 # Multi constructor dynamic memory config, hacking own units
 # Health: Frozen to at least 200
@@ -10,57 +10,38 @@ wesnoth
 # TODO: Need experience = (experience_max - 1) handling to avoid
 #       advancing multiple levels at once.
 # TODO: Experience: Need toggling between watching and active.
-# TODO: Need direct C string support to read the name of the unit.
 
+# Find constructors:
+# objdump -D `which wesnoth` 2>&1 | grep -A20 "\$0x750,%edi" | grep -A1 _Znwm | grep -v _Znwm | cut -d ':' -f1 > addrs.txt
+# IFS=$'\n'; for i in `sed /--/d addrs.txt | tr -d [:blank:]`; do echo "dynmemconst 1872 0x$i 0x8"; done
 
 # Team check. Player controls team 1. Others at 2, 3, 4, etc.
-define TEAM_CHECK checko 0x14c i32 e 1
+define TEAM_CHECK checko 0x164 i32 e 1
 
-# Unit constructors: Game load
-dynmemstart Unit 1848 0x8df332 0x8
-# Recruit/Recall
-dynmemconst 1848 0x5e35dd 0x8
-# Tutorial start Konrad
-dynmemconst 1848 0x47dbc8 0x8
-# Experience level up Konrad during tutorial
-dynmemconst 1848 0x5cee4d 0x8
-# Unknown, taken from disassembly search \$0x738,%edi for _Znwm()
-dynmemconst 1848 0x46d9b6 0x8
-dynmemconst 1848 0x46dd97 0x8
-dynmemconst 1848 0x472a1e 0x8
-dynmemconst 1848 0x472ead 0x8
-dynmemconst 1848 0x473061 0x8
-dynmemconst 1848 0x4d2198 0x8
-dynmemconst 1848 0x4d6118 0x8
-dynmemconst 1848 0x55e7e2 0x8
-dynmemconst 1848 0x5754d4 0x8
-dynmemconst 1848 0x5aad47 0x8
-dynmemconst 1848 0x5b41b7 0x8
-dynmemconst 1848 0x5b598f 0x8
-dynmemconst 1848 0x5b59bf 0x8
-dynmemconst 1848 0x5b5c35 0x8
-dynmemconst 1848 0x5b7d8f 0x8
-dynmemconst 1848 0x5b7efe 0x8
-dynmemconst 1848 0x5b8187 0x8
-dynmemconst 1848 0x5cefbd 0x8
-dynmemconst 1848 0x5db482 0x8
-dynmemconst 1848 0x63197f 0x8
-dynmemconst 1848 0x6a24ec 0x8
-dynmemconst 1848 0x72aac5 0x8
-dynmemconst 1848 0x72b29a 0x8
-dynmemconst 1848 0x86ec03 0x8
-dynmemconst 1848 0x8aa891 0x8
-dynmemconst 1848 0x8b0ebf 0x8
-dynmemconst 1848 0x8b0f78 0x8
-dynmemconst 1848 0x8b1024 0x8
-dynmemconst 1848 0x96671e 0x8
-dynmemconst 1848 0x966b72 0x8
-dynmemconst 1848 0x967d25 0x8
-dynmemconst 1848 0x987d27 0x8
-dynmemconst 1848 0x987d8a 0x8
-dynmemconst 1848 0xa7d443 0x8
+# Unit constructors
+dynmemstart Unit 1872 0x4838e0 0x8
+dynmemconst 1872 0x483bfa 0x8
+dynmemconst 1872 0x483e60 0x8
+dynmemconst 1872 0x493106 0x8
+dynmemconst 1872 0x4e6845 0x8
+dynmemconst 1872 0x4eaf2f 0x8
+dynmemconst 1872 0x5cfa86 0x8
+dynmemconst 1872 0x5f994e 0x8
+dynmemconst 1872 0x5fe5d6 0x8
+dynmemconst 1872 0x6c0eac 0x8
+dynmemconst 1872 0x74bbde 0x8
+dynmemconst 1872 0x74c4ab 0x8
+dynmemconst 1872 0x8913e9 0x8
+dynmemconst 1872 0x8ce8fe 0x8
+dynmemconst 1872 0x8d5207 0x8
+dynmemconst 1872 0x8d53a4 0x8
+dynmemconst 1872 0x904888 0x8
+dynmemconst 1872 0x98bf28 0x8
+dynmemconst 1872 0x9ae5c8 0x8
 
-HealthMax 0xcc i32 l 200 1,0 a
+Name 0x78 cstr watch
+
+HealthMax 0xe4 i32 l 200 1,0 a
 TEAM_CHECK
 Health prev-4 i32 HealthMax 1,0 a
 
@@ -69,12 +50,12 @@ TEAM_CHECK
 Exp prev-4 i32 ExpMax 2,0 w
 Level prev+8 i32 watch
 
-MovesMax 0x164 i32 l 20 3,0 a
+MovesMax 0x17c i32 l 20 3,0 a
 TEAM_CHECK
 Moves prev-4 i32 MovesMax 3,0 a
 
 # Often set/unset together with a bool at 0x2ba
-CanAttack 0x2bc u8 max 4,0 a
+CanAttack 0x2d4 u8 max 4,0 a
 TEAM_CHECK
 check this u8 l 2
 
@@ -83,11 +64,13 @@ dynmemend
 
 # Use dynmem growing by multiplication (1..5 * 976):
 
+# Adapt:
+# objdump -D `which wesnoth` 2>&1 | grep -C1 "<_Znwm@plt>" | grep -A2 "imul .*\$0x3d0,"
 #  75f791:       49 69 ff d0 03 00 00    imul   $0x3d0,%r15,%rdi
 #  75f798:       e8 f3 78 ba ff          callq  307090 <_Znwm@plt>
 #  75f79d:       49 89 c7                mov    %rax,%r15
 
-dynmemgrow PlayerData 1 5 *976 0x75f79d 0x8
+dynmemgrow PlayerData 1 5 *976 0x77f93f 0x8
 
 Gold 0x8 i32 l 800 5,0 a
 

--- a/examples/incomplete/wesnoth64.conf
+++ b/examples/incomplete/wesnoth64.conf
@@ -1,0 +1,92 @@
+wesnoth
+
+# Battle for Wesnoth 1.15.3-lp151.38.1, openSUSE Leap 15.1, 64 bit, PIE
+
+# Multi constructor dynamic memory config, hacking own units
+# Health: Frozen to at least 200
+# Moves:  Frozen to at least 20
+# Attack: Can always attack.
+# Watching experience (current, max) and unit level
+# TODO: Need experience = (experience_max - 1) handling to avoid
+#       advancing multiple levels at once.
+# TODO: Experience: Need toggling between watching and active.
+# TODO: Need direct C string support to read the name of the unit.
+# TODO: Gold modification in development
+
+
+# Team check. Player controls team 1. Others at 2, 3, 4, etc.
+define TEAM_CHECK checko 0x14c i32 e 1
+
+# Unit constructors: Game load
+dynmemstart Unit 1848 0x8df332 0x8
+# Recruit/Recall
+dynmemconst 1848 0x5e35dd 0x8
+# Tutorial start Konrad
+dynmemconst 1848 0x47dbc8 0x8
+# Experience level up Konrad during tutorial
+dynmemconst 1848 0x5cee4d 0x8
+# Unknown, taken from disassembly search \$0x738,%edi for _Znwm()
+dynmemconst 1848 0x46d9b6 0x8
+dynmemconst 1848 0x46dd97 0x8
+dynmemconst 1848 0x472a1e 0x8
+dynmemconst 1848 0x472ead 0x8
+dynmemconst 1848 0x473061 0x8
+dynmemconst 1848 0x4d2198 0x8
+dynmemconst 1848 0x4d6118 0x8
+dynmemconst 1848 0x55e7e2 0x8
+dynmemconst 1848 0x5754d4 0x8
+dynmemconst 1848 0x5aad47 0x8
+dynmemconst 1848 0x5b41b7 0x8
+dynmemconst 1848 0x5b598f 0x8
+dynmemconst 1848 0x5b59bf 0x8
+dynmemconst 1848 0x5b5c35 0x8
+dynmemconst 1848 0x5b7d8f 0x8
+dynmemconst 1848 0x5b7efe 0x8
+dynmemconst 1848 0x5b8187 0x8
+dynmemconst 1848 0x5cefbd 0x8
+dynmemconst 1848 0x5db482 0x8
+dynmemconst 1848 0x63197f 0x8
+dynmemconst 1848 0x6a24ec 0x8
+dynmemconst 1848 0x72aac5 0x8
+dynmemconst 1848 0x72b29a 0x8
+dynmemconst 1848 0x86ec03 0x8
+dynmemconst 1848 0x8aa891 0x8
+dynmemconst 1848 0x8b0ebf 0x8
+dynmemconst 1848 0x8b0f78 0x8
+dynmemconst 1848 0x8b1024 0x8
+dynmemconst 1848 0x96671e 0x8
+dynmemconst 1848 0x966b72 0x8
+dynmemconst 1848 0x967d25 0x8
+dynmemconst 1848 0x987d27 0x8
+dynmemconst 1848 0x987d8a 0x8
+dynmemconst 1848 0xa7d443 0x8
+
+HealthMax 0xcc i32 l 200 1,0 a
+TEAM_CHECK
+Health prev-4 i32 HealthMax 1,0 a
+
+ExpMax prev+12 i32 l 200 2,0 w
+TEAM_CHECK
+Exp prev-4 i32 ExpMax 2,0 w
+Level prev+8 i32 watch
+
+MovesMax 0x164 i32 l 20 3,0 a
+TEAM_CHECK
+Moves prev-4 i32 MovesMax 3,0 a
+
+# Often set/unset together with a bool at 0x2ba
+CanAttack 0x2bc u8 max 4,0 a
+TEAM_CHECK
+check this u8 l 2
+
+dynmemend
+
+
+# Still unreliable. Works for some missions.
+# Likely more constructors and a check are required.
+
+dynmemstart PlayerData 2928 0x75f79d 0x8
+
+Gold 0x8 i32 l 800 5,0 a
+
+dynmemend

--- a/src/aslr.cpp
+++ b/src/aslr.cpp
@@ -1,6 +1,6 @@
 /* aslr.cpp:    handle Address Space Layout Randomization (ASLR)
  *
- * Copyright (c) 2012..2019 Sebastian Parschauer <s.parschauer@gmx.de>
+ * Copyright (c) 2012..2020 Sebastian Parschauer <s.parschauer@gmx.de>
  *
  * This file may be used subject to the terms and conditions of the
  * GNU General Public License Version 3, or any later version
@@ -341,11 +341,9 @@ void handle_aslr (Options *opt, list<CfgEntry> *cfg, i32 ifd,
 			grow = dynmem->grow;
 			old_dynmem = dynmem;
 			HANDLE_DYNMEM_ESSENTIALS(dynmem);
-			vector<DynMemEssentials>::iterator vit;
-			if (dynmem->consts) {
-				vect_for_each (dynmem->consts, vit)
-					HANDLE_DYNMEM_ESSENTIALS(vit);
-			}
+			vector<DynMemEssentials>::iterator esit;
+			vect_for_each (dynmem->consts, esit)
+				HANDLE_DYNMEM_ESSENTIALS(esit);
 			if (grow) {
 				if (!grow->lib || grow->lib->empty())
 					code_offs = exe_offs;

--- a/src/cfgentry.h
+++ b/src/cfgentry.h
@@ -145,6 +145,7 @@ struct type {
 	bool on_stack;
 	bool is_signed;
 	bool is_float;
+	bool is_cstr;
 	bool is_cstrp;
 	i32 size;
 };

--- a/src/cfgentry.h
+++ b/src/cfgentry.h
@@ -195,6 +195,7 @@ public:
 	bool val_set;                 // Value has been written this cycle?
 
 	CfgEntry *cfg_ref;            // value from another cfg entry (DYN_VAL_ADDR)
+	i64 cfg_ref_add;              // What needs to be added to the cfg_ref value?
 	list<CheckEntry> *checks;     // more checks
 
 	// dynamic memory

--- a/src/cfgentry.h
+++ b/src/cfgentry.h
@@ -70,16 +70,18 @@ public:
 
 class CfgEntry;
 
-class DynMemEntry {
-public:
-	string name;
+struct DynMemEssentials {
 	size_t mem_size;
 	ptr_t code_addr;
 	ptr_t code_offs;              // for late PIC support
 	ptr_t stack_offs;
 	string *lib;                  // for PIC support
-	GrowEntry *grow;
+};
 
+struct DynMemEntry : DynMemEssentials {
+	string name;
+	vector<DynMemEssentials> *consts;
+	GrowEntry *grow;
 	list<CfgEntry*> cfg_act;
 
 	// later determined values

--- a/src/cfgentry.h
+++ b/src/cfgentry.h
@@ -63,9 +63,6 @@ public:
 	ptr_t code_offs;              // for late PIC support
 	ptr_t stack_offs;
 	string *lib;                  // for PIC support
-
-	// later determined values
-	vector<size_t> v_msize;       // set by malloc/realloc calls
 };
 
 class CfgEntry;
@@ -86,6 +83,7 @@ struct DynMemEntry : DynMemEssentials {
 
 	// later determined values
 	vector<ptr_t> v_maddr;        // set by malloc calls
+	vector<size_t> v_msize;       // set by malloc/realloc calls
 	u32 num_alloc;                // how many obj. created at once
 	u32 num_freed;                // how many obj. freed at once
 	u32 obj_idx;                  // object index for object check

--- a/src/cfgoutput.cpp
+++ b/src/cfgoutput.cpp
@@ -1,6 +1,6 @@
 /* cfgoutput.cpp:    output functions for the ugtrain config
  *
- * Copyright (c) 2012..2018 Sebastian Parschauer <s.parschauer@gmx.de>
+ * Copyright (c) 2012..2020 Sebastian Parschauer <s.parschauer@gmx.de>
  *
  * This file may be used subject to the terms and conditions of the
  * GNU General Public License Version 3, or any later version
@@ -303,13 +303,11 @@ void output_config (Options *opt, list<CfgEntry> *cfg)
 			}
 			OUTPUT_CACHE(dynmem);
 			cout << endl;
-			if (dynmem->consts) {
-				vector<DynMemEssentials>::iterator vit;
-				vect_for_each (dynmem->consts, vit) {
-					ugout << " constructor: "
-					      << OUTPUT_DYNMEM_ESSENTIALS(vit);
-					cout << endl;
-				}
+			vector<DynMemEssentials>::iterator esit;
+			vect_for_each (dynmem->consts, esit) {
+				ugout << " constructor: "
+				      << OUTPUT_DYNMEM_ESSENTIALS(esit);
+				cout << endl;
 			}
 		} else if (cfg_en->ptrmem) {
 			PtrMemEntry *ptrmem = cfg_en->ptrmem;

--- a/src/cfgoutput.cpp
+++ b/src/cfgoutput.cpp
@@ -258,6 +258,9 @@ static void output_grow_method (GrowEntry *grow)
 	case GROW_ADD:
 		cout << "+" << grow->add;
 		break;
+	case GROW_MUL:
+		cout << "*" << grow->add;
+		break;
 	default:
 		cout << "unknown";
 		break;

--- a/src/cfgoutput.cpp
+++ b/src/cfgoutput.cpp
@@ -82,6 +82,8 @@ static void output_config_val (CfgEntry *cfg_en)
 	case DYN_VAL_WATCH:
 		if (cfg_en->type.is_cstrp)
 			cout << "cstrp ";
+		else if (cfg_en->type.is_cstr)
+			cout << "cstr ";
 		cout << "(watch)" << endl;
 		break;
 	case DYN_VAL_MIN:

--- a/src/cfgoutput.cpp
+++ b/src/cfgoutput.cpp
@@ -95,11 +95,17 @@ static void output_config_val (CfgEntry *cfg_en)
 		cout << endl;
 		break;
 	case DYN_VAL_ADDR:
-		if (cfg_en->cfg_ref)
-			cout << cfg_en->cfg_ref->name << endl;
-		else
+		if (cfg_en->cfg_ref) {
+			if (cfg_en->cfg_ref_add == 0)
+				cout << cfg_en->cfg_ref->name << endl;
+			else if (cfg_en->cfg_ref_add > 0)
+				cout << cfg_en->cfg_ref->name << "+" << cfg_en->cfg_ref_add << endl;
+			else
+				cout << cfg_en->cfg_ref->name << cfg_en->cfg_ref_add << endl;
+		} else {
 			cout << "0x" << hex << cfg_en->value.i64
 				<< " (from addr)" << dec << endl;
+		}
 		break;
 	default:
 		output_val(&cfg_en->type, cfg_en->value, "");

--- a/src/cfgparser.cpp
+++ b/src/cfgparser.cpp
@@ -836,12 +836,19 @@ static void parse_growing (DynMemEntry *dynmem_enp, string *line, u32 lnr,
 		    grow_enp->add > grow_enp->size_max -
 		    grow_enp->size_min)
 			cfg_parse_err(line, lnr, --lidx);
+	} else if (line->at(lidx) == '*') {
+		grow_enp->type = GROW_MUL;
+		*start = ++lidx;
+		grow_enp->add = parse_u32_value(line, lnr, start);
+		if (grow_enp->size_min < 1 || grow_enp->add <= 0 ||
+		    grow_enp->size_max < grow_enp->size_min)
+			cfg_parse_err(line, lnr, --lidx);
 	} else {
 		cfg_parse_err(line, lnr, --lidx);
 	}
 	// parse backtracing
 	_PARSE_DYNMEM_ESSENTIALS(grow_enp);
-	grow_enp->v_msize.clear();
+	dynmem_enp->v_msize.clear();
 	dynmem_enp->grow = grow_enp;
 }
 
@@ -874,6 +881,7 @@ static void parse_dynmem (DynMemEntry *dynmem_enp, bool from_grow,
 	dynmem_enp->cache_list->push_back(cache);
 	dynmem_enp->grow = NULL;
 	dynmem_enp->v_maddr.clear();
+	dynmem_enp->v_msize.clear();
 }
 
 static inline void pr_warn_statmem_ptr (void)

--- a/src/cfgparser.cpp
+++ b/src/cfgparser.cpp
@@ -1,6 +1,6 @@
 /* cfgparser.cpp:    parsing functions to read in the config file
  *
- * Copyright (c) 2012..2018 Sebastian Parschauer <s.parschauer@gmx.de>
+ * Copyright (c) 2012..2020 Sebastian Parschauer <s.parschauer@gmx.de>
  *
  * This file may be used subject to the terms and conditions of the
  * GNU General Public License Version 3, or any later version
@@ -853,8 +853,6 @@ static void parse_dynmem (DynMemEntry *dynmem_enp, bool from_grow,
 	if (from_const) {
 		DynMemEssentials dynmem_es, *dynmem_esp = &dynmem_es;
 		PARSE_DYNMEM_ESSENTIALS(dynmem_esp);
-		if (!dynmem_enp->consts)
-			dynmem_enp->consts = new vector<DynMemEssentials>;
 		dynmem_enp->consts->push_back(*dynmem_esp);
 		return;
 	}
@@ -870,6 +868,7 @@ static void parse_dynmem (DynMemEntry *dynmem_enp, bool from_grow,
 		PARSE_DYNMEM_ESSENTIALS(dynmem_enp);
 		dynmem_enp->cfg_line = lnr;
 	}
+	dynmem_enp->consts = new vector<DynMemEssentials>;
 	init_cache(&cache, PTR_MAX);
 	dynmem_enp->cache_list = new list<CacheEntry>;
 	dynmem_enp->cache_list->push_back(cache);

--- a/src/common.h
+++ b/src/common.h
@@ -24,7 +24,8 @@
 
 /* common types */
 enum grow_type {
-	GROW_ADD
+	GROW_ADD,
+	GROW_MUL
 };
 
 /* Common defines */

--- a/src/dump.cpp
+++ b/src/dump.cpp
@@ -11,6 +11,7 @@
  * GNU General Public License for more details.
  */
 
+#include <algorithm>
 #include <fcntl.h>
 #include <unistd.h>
 #include <stdio.h>
@@ -130,6 +131,8 @@ void dump_all_mem_obj (pid_t pid, Options *opt)
 	list_for_each (cfg, it) {
 		if (!it->dynmem || it->dynmem == old_dynmem)
 			continue;
+		vector<size_t> *svec = &it->dynmem->v_msize;
+		vector<DynMemEssentials>::iterator esit;
 		obj_id = 0;
 		for (i = 0; i < it->dynmem->v_maddr.size(); i++) {
 			ugout << ">>> Dumping Class " << main_id
@@ -138,7 +141,7 @@ void dump_all_mem_obj (pid_t pid, Options *opt)
 			      << dec << endl;
 			dump_mem_obj(pid, mfd, NULL, main_id, obj_id,
 				     it->dynmem->v_maddr[obj_id],
-				     it->dynmem->mem_size);
+				     svec->at(obj_id));
 			obj_id++;
 		}
 		main_id++;

--- a/src/linuxhooking/libmemdisc.c
+++ b/src/linuxhooking/libmemdisc.c
@@ -606,11 +606,7 @@ static inline bool find_code_addresses (ptr_t ffp, char *obuf, i32 *obuf_offs)
 	i32 i = 0;
 	bool found = false;
 
-	/*
-	 * check if we are in the correct section
-	 * -> we shouldn't be more that 16 MiB away
-	 */
-	if (!ffp || ffp < stack_end - (1 << 24))
+	if (!ffp)
 		return false;
 
 	for (offs = ffp;
@@ -720,8 +716,12 @@ void postprocess_malloc (ptr_t ffp, size_t size, ptr_t mem_addr)
 			found = run_gnu_backtrace(obuf, &obuf_offs);
 		else
 			found = find_code_addresses(ffp, obuf, &obuf_offs);
-		if (!found)
+		if (!found) {
+#if DEBUG_MEM
+			pr_out("find_code_addresses() failed!\n");
+#endif
 			goto out;
+		}
 	}
 	wbytes = snprintf(obuf + obuf_offs, BUF_SIZE - obuf_offs, "\n");
 	if (wbytes < 0)

--- a/src/memmgmt.cpp
+++ b/src/memmgmt.cpp
@@ -1,6 +1,6 @@
 /* memmgmt.cpp:    allocation and freeing of objects and values
  *
- * Copyright (c) 2012..2018 Sebastian Parschauer <s.parschauer@gmx.de>
+ * Copyright (c) 2012..2020 Sebastian Parschauer <s.parschauer@gmx.de>
  *
  * This file may be used subject to the terms and conditions of the
  * GNU General Public License Version 3, or any later version
@@ -306,14 +306,12 @@ void alloc_dynmem_addr (MF_PARAMS)
 			svec->push_back(mem_size);
 		} else if (dynmem->code_addr != code_addr) {
 			bool found = false;
-			if (dynmem->consts) {
-				vector<DynMemEssentials>::iterator vit;
-				vect_for_each (dynmem->consts, vit) {
-					if (vit->code_addr == code_addr) {
-						found = true;
-						break;
-					}
-				}
+			vector<DynMemEssentials>::iterator esit;
+			vect_for_each (dynmem->consts, esit) {
+				if (likely(esit->code_addr != code_addr))
+					continue;
+				found = true;
+				break;
 			}
 			if (!found)
 				continue;

--- a/src/memmgmt.cpp
+++ b/src/memmgmt.cpp
@@ -305,7 +305,18 @@ void alloc_dynmem_addr (MF_PARAMS)
 			svec = &grow->v_msize;
 			svec->push_back(mem_size);
 		} else if (dynmem->code_addr != code_addr) {
-			continue;
+			bool found = false;
+			if (dynmem->consts) {
+				vector<DynMemEssentials>::iterator vit;
+				vect_for_each (dynmem->consts, vit) {
+					if (vit->code_addr == code_addr) {
+						found = true;
+						break;
+					}
+				}
+			}
+			if (!found)
+				continue;
 		}
 		mvec = &dynmem->v_maddr;
 		mvec->push_back(mem_addr);

--- a/src/memmgmt.cpp
+++ b/src/memmgmt.cpp
@@ -36,7 +36,7 @@ static void alloc_ptrmem (CfgEntry *cfg_en)
 		cfg_en->v_oldval.push_back(def_val);
 		cfg_en->v_value.push_back(cfg_en->value);
 		cstr = NULL;
-		if (cfg_en->type.is_cstrp)
+		if (cfg_en->type.is_cstrp || cfg_en->type.is_cstr)
 			cstr = (char *) calloc(1, MAX_CSTR + 1);
 		cfg_en->v_cstr.push_back(cstr);
 	}
@@ -63,7 +63,7 @@ void alloc_dynmem (list<CfgEntry> *cfg)
 				cfg_en->v_oldval.push_back(def_val);
 				cfg_en->v_value.push_back(cfg_en->value);
 				cstr = NULL;
-				if (cfg_en->type.is_cstrp)
+				if (cfg_en->type.is_cstrp || cfg_en->type.is_cstr)
 					cstr = (char *) calloc(1, MAX_CSTR + 1);
 				cfg_en->v_cstr.push_back(cstr);
 				if (cfg_en->ptrtgt)

--- a/src/ugtrain.cpp
+++ b/src/ugtrain.cpp
@@ -1,6 +1,6 @@
 /* ugtrain.cpp:    freeze values in process memory (game trainer)
  *
- * Copyright (c) 2012..2019 Sebastian Parschauer <s.parschauer@gmx.de>
+ * Copyright (c) 2012..2020 Sebastian Parschauer <s.parschauer@gmx.de>
  *
  * This file may be used subject to the terms and conditions of the
  * GNU General Public License Version 3, or any later version
@@ -892,12 +892,10 @@ static i32 prepare_dynmem (Options *opt, list<CfgEntry> *cfg,
 			       (grow->lib != old_lib)))) {
 			num_cfg++;
 			ADD_DYNMEM_ESSENTIALS(dynmem);
-			if (dynmem->consts) {
-				vector<DynMemEssentials>::iterator vit;
-				vect_for_each (dynmem->consts, vit) {
-					num_cfg++;
-					ADD_DYNMEM_ESSENTIALS(vit);
-				}
+			vector<DynMemEssentials>::iterator esit;
+			vect_for_each (dynmem->consts, esit) {
+				num_cfg++;
+				ADD_DYNMEM_ESSENTIALS(esit);
 			}
 			if (grow) {
 				pos += snprintf(obuf + pos, sizeof(obuf) - pos,

--- a/src/ugtrain.cpp
+++ b/src/ugtrain.cpp
@@ -564,12 +564,7 @@ process_dynmem_cfg_act (pid_t pid, list<CfgEntry*> *cfg_act,
 			if (!mem_offs)
 				continue;
 			// check for out of bounds access
-			if (dynmem->grow) {
-				GrowEntry *grow = dynmem->grow;
-				mem_size = grow->v_msize[mem_idx];
-			} else {
-				mem_size = dynmem->mem_size;
-			}
+			mem_size = dynmem->v_msize[mem_idx];
 			if (cfg_en->addr + type->size / 8 > mem_size)
 				continue;
 			dynmem->obj_idx = mem_idx;
@@ -899,9 +894,10 @@ static i32 prepare_dynmem (Options *opt, list<CfgEntry> *cfg,
 			}
 			if (grow) {
 				pos += snprintf(obuf + pos, sizeof(obuf) - pos,
-					";grow;%lu;%lu;+%u;" SCN_PTR ";" SCN_PTR,
+					";grow;%lu;%lu;%c%u;" SCN_PTR ";" SCN_PTR,
 					(ulong) grow->size_min,	(ulong)
-					grow->size_max, grow->add,
+					grow->size_max, (grow->type == GROW_MUL) ?
+					'*' : '+', grow->add,
 					grow->code_addr,
 					grow->stack_offs);
 				if (grow->lib)

--- a/src/ugtrain.cpp
+++ b/src/ugtrain.cpp
@@ -299,10 +299,12 @@ static void handle_dynval (pid_t pid, CfgEntry *cfg_en, T read_val,
 		break;
 	case DYN_VAL_ADDR:
 		if (cfg_en->cfg_ref) {
-			if (handle_cfg_ref(cfg_en->cfg_ref, buf) != 0)
+			if (handle_cfg_ref(cfg_en->cfg_ref, buf) != 0) {
 				*value = 0;
-			else
+			} else {
 				*value = *(T *) buf;
+				*value += cfg_en->cfg_ref_add;
+			}
 		} else {
 			mem_addr = mem_offs + cfg_en->val_addr;
 			if (read_memory(pid, mem_addr, buf, "DYNVAL MEMORY"))

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -107,7 +107,12 @@ void clear_config (void)
 	list_for_each (cfg, it) {
 		DynMemEntry *dynmem = it->dynmem;
 		PtrMemEntry *ptrmem = it->ptrmem;
-		if (dynmem)
+		if (dynmem) {
+			if (dynmem->grow) {
+				if (dynmem->grow->lib)
+					delete dynmem->grow->lib;
+				delete dynmem->grow;
+			}
 			CLEANUP_MEM(dynmem,
 				if (dynmem->lib)
 					delete dynmem->lib;
@@ -119,6 +124,7 @@ void clear_config (void)
 				dynmem->consts->clear();
 				delete dynmem->consts;
                         );
+		}
 		else if (ptrmem)
 			CLEANUP_MEM(ptrmem, ;);
 		// Clean up checks

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1,6 +1,6 @@
 /* util.cpp:    C++ utility functions
  *
- * Copyright (c) 2018 Sebastian Parschauer <s.parschauer@gmx.de>
+ * Copyright (c) 2018..2020 Sebastian Parschauer <s.parschauer@gmx.de>
  *
  * This file may be used subject to the terms and conditions of the
  * GNU General Public License Version 3, or any later version
@@ -109,7 +109,16 @@ void clear_config (void)
 		PtrMemEntry *ptrmem = it->ptrmem;
 		if (dynmem)
 			CLEANUP_MEM(dynmem,
-				if (dynmem->lib) delete dynmem->lib);
+				if (dynmem->lib)
+					delete dynmem->lib;
+				vector<DynMemEssentials>::iterator esit;
+				vect_for_each (dynmem->consts, esit) {
+					if (esit->lib)
+						delete esit->lib;
+				}
+				dynmem->consts->clear();
+				delete dynmem->consts;
+                        );
 		else if (ptrmem)
 			CLEANUP_MEM(ptrmem, ;);
 		// Clean up checks

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -98,7 +98,7 @@ void clear_config (void)
 	list_for_each (cfg, it) {
 		if (it->dynmem || it->ptrmem)
 			continue;
-		if (it->type.is_cstrp)
+		if (it->type.is_cstrp || it->type.is_cstr)
 			free(it->cstr);
 		if (it->type.lib_name)
 			delete it->type.lib_name;

--- a/src/valoutput.cpp
+++ b/src/valoutput.cpp
@@ -26,7 +26,7 @@ static void output_mem_val (CfgEntry *cfg_en, ptr_t mem_offs, bool is_dynmem)
 	if (cfg_en->ptrmem) {
 		dynmem = cfg_en->ptrmem->dynmem;
 		if (dynmem && dynmem->v_maddr.size() > 1)
-			cout << " -> " << cfg_en->name << "[" << dynmem->pr_idx << "]"
+			cout << " -> " << cfg_en->name << "[" << dec << dynmem->pr_idx << "]"
 			     << " at 0x" << hex << cfg_en->addr + mem_offs
 			     << ", Data: 0x";
 		else
@@ -34,7 +34,7 @@ static void output_mem_val (CfgEntry *cfg_en, ptr_t mem_offs, bool is_dynmem)
 			     << cfg_en->addr + mem_offs
 			     << ", Data: 0x";
 	} else if (is_dynmem && cfg_en->dynmem->v_maddr.size() > 1) {
-		ugout << cfg_en->name << "[" << cfg_en->dynmem->pr_idx << "]"
+		ugout << cfg_en->name << "[" << dec << cfg_en->dynmem->pr_idx << "]"
 		      << " at 0x" << hex << cfg_en->addr + mem_offs
 		      << ", Data: 0x";
 	} else {
@@ -115,7 +115,7 @@ static void output_ptrmem_values (CfgEntry *cfg_en)
 	mem_offs = cfg_en->ptrtgt->v_offs[pr_idx];
 	if (!mem_offs || cfg_en->ptrtgt->v_state[pr_idx] < PTR_SETTLED)
 		return;
-	cout << " -> *" << cfg_en->ptrtgt->name << "[" << pr_idx << "]"
+	cout << " -> *" << cfg_en->ptrtgt->name << "[" << dec << pr_idx << "]"
 	     << " = 0x" << hex << mem_offs << dec << endl;
 
 	list_for_each (cfg_act, it) {
@@ -158,7 +158,7 @@ int output_mem_values (list<CfgEntry*> *cfg_act)
 				is_dynmem = true;
 				if (cfg_en->dynmem != old_dynmem) {
 					ugout << "*" << cfg_en->dynmem->name << "["
-					      << cfg_en->dynmem->pr_idx << "]" << " = 0x"
+					      << dec << cfg_en->dynmem->pr_idx << "]" << " = 0x"
 					      << hex << mem_offs << dec << ", "
 					      << mvec->size() << " obj." << endl;
 						 old_dynmem = cfg_en->dynmem;

--- a/src/valoutput.cpp
+++ b/src/valoutput.cpp
@@ -48,6 +48,10 @@ static void output_mem_val (CfgEntry *cfg_en, ptr_t mem_offs, bool is_dynmem)
 		     << " (\"" << cfg_en->cstr << "\")" << endl;
 		return;
 	}
+	if (type->is_cstr && cfg_en->cstr) {
+		cout << "0 (\"" << cfg_en->cstr << "\")" << endl;
+		return;
+	}
 
 	if (type->is_float) {
 		if (type->size == 32) {


### PR DESCRIPTION
In order to support the Battle for Wesnoth, the following tasks are required:
* [x] libmemdisc: Drop frame pointer stack limit check
* [x] Implement the "dynmemconst" multi constructor support
* [x] Modify dynmem dumping for "dynmemconst" support (use actual object size)
* [x] Add the wesnoth64 config to the examples
* [x] Implement growing by multiplication support
* [x] Implement further functionality found missing and needed for this game
* [ ] Document that there are games with misc regions as additional stack and heap regions
* [ ] Document the "dynmemconst" multi constructor support
* [ ] Document the "dynmemgrow" support
* [ ] Document the support for value reference +/- offset (Unit experience in `wesnoth`)    